### PR TITLE
Decarabia Map Correctness Check

### DIFF
--- a/code/modules/unit_tests/_map_correctness/__map_correctness.dm
+++ b/code/modules/unit_tests/_map_correctness/__map_correctness.dm
@@ -34,6 +34,17 @@
 			STOP_TRACKING; \
 			. = ..(); \
 		}
+
+	#define SET_UP_CI_TRACKING_TURF(TYPE) \
+		TYPE/New() { \
+			. = ..(); \
+			START_TRACKING; \
+		} \
+		TYPE/Del() { \
+			STOP_TRACKING; \
+			. = ..(); \
+		}
 #else
 	#define SET_UP_CI_TRACKING(TYPE)
+	#define SET_UP_CI_TRACKING_TURF(TYPE)
 #endif

--- a/code/modules/unit_tests/_map_correctness/decarabia_only.dm
+++ b/code/modules/unit_tests/_map_correctness/decarabia_only.dm
@@ -13,9 +13,10 @@
 		/obj/machinery/door/airlock/walp,
 	)
 
+	var/is_decarabia = istype(global.map_settings, /datum/map_settings/decarabia)
 	for (var/type as anything in blacklist_types)
 		for (var/atom/A as anything in global.by_type[type])
-			if ((A.z == Z_LEVEL_STATION) && istype(global.map_settings, /datum/map_settings/decarabia))
+			if ((A.z == Z_LEVEL_STATION) && is_decarabia)
 				continue
 
 			. += src.format_position(A)

--- a/code/modules/unit_tests/_map_correctness/decarabia_only.dm
+++ b/code/modules/unit_tests/_map_correctness/decarabia_only.dm
@@ -1,0 +1,30 @@
+/datum/map_correctness_check/decarabia_only
+	check_name = "Decarabia-Only Objects"
+
+/datum/map_correctness_check/decarabia_only/run_check()
+	. = list()
+	var/blacklist_types = list(
+		/turf/simulated/wall/auto/walp,
+		/turf/simulated/wall/auto/reinforced/walp,
+		/obj/window/auto/walp,
+		/obj/window/auto/reinforced/walp,
+		/obj/window/auto/crystal/walp,
+		/obj/window/auto/crystal/reinforced/walp,
+		/obj/machinery/door/airlock/walp,
+	)
+
+	for (var/type as anything in blacklist_types)
+		for (var/atom/A as anything in global.by_type[type])
+			if ((A.z == Z_LEVEL_STATION) && istype(global.map_settings, /datum/map_settings/decarabia))
+				continue
+
+			. += src.format_position(A)
+
+
+SET_UP_CI_TRACKING_TURF(/turf/simulated/wall/auto/walp)
+SET_UP_CI_TRACKING_TURF(/turf/simulated/wall/auto/reinforced/walp)
+SET_UP_CI_TRACKING(/obj/window/auto/walp)
+SET_UP_CI_TRACKING(/obj/window/auto/reinforced/walp)
+SET_UP_CI_TRACKING(/obj/window/auto/crystal/walp)
+SET_UP_CI_TRACKING(/obj/window/auto/crystal/reinforced/walp)
+SET_UP_CI_TRACKING(/obj/machinery/door/airlock/walp)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -2367,6 +2367,7 @@
 #include "code\modules\unit_tests\_map_correctness\_map_correctness_check.dm"
 #include "code\modules\unit_tests\_map_correctness\apcless_areas.dm"
 #include "code\modules\unit_tests\_map_correctness\blind_switches.dm"
+#include "code\modules\unit_tests\_map_correctness\decarabia_only.dm"
 #include "code\modules\unit_tests\_map_correctness\directional_objects.dm"
 #include "code\modules\unit_tests\_map_correctness\door_turfs.dm"
 #include "code\modules\unit_tests\_map_correctness\duplicate_area_names.dm"


### PR DESCRIPTION
## About The PR:
Checks for the presence of the following types on non-Decarabia maps:
`/turf/simulated/wall/auto/walp`
`/turf/simulated/wall/auto/reinforced/walp`
`/obj/window/auto/walp`
`/obj/window/auto/reinforced/walp`
`/obj/window/auto/crystal/walp`
`/obj/window/auto/crystal/reinforced/walp`
`/obj/machinery/door/airlock/walp`


## Testing:
Tested using a malformed `cogmap.dmm`:

<img width="956" height="292" alt="image" src="https://github.com/user-attachments/assets/bab759ef-ac90-4b2a-a182-35ea6bb36a2a" />